### PR TITLE
Bump semigroupoids upper bound to 5.3

### DIFF
--- a/wires.cabal
+++ b/wires.cabal
@@ -33,7 +33,7 @@ library
         deepseq == 1.4.*,
         mtl >= 2.0 && < 2.3,
         profunctors >= 5.0 && < 5.3,
-        semigroupoids >= 5.0 && < 5.2,
+        semigroupoids >= 5.0 && < 5.3,
         these == 0.7.*
     default-language: Haskell2010
     ghc-options: -W


### PR DESCRIPTION
Newer Stackage snapshots are incompatible with wires due to them containing `semigroupoids-5.2.0` or newer. I have only changed the version bound here, but the library compiles and the examples still work as expected.